### PR TITLE
BAH-1632 | Add. Home button to go back to Bahmni dashboard  screen

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -12,6 +12,13 @@
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
       "name": " "
+    },
+    "extensionSlots": {
+      "top-nav-actions-slot": {
+        "remove": [
+          "add-patient-action"
+        ]
+      }
     }
   },
   "@openmrs/esm-patient-search-app": {

--- a/config/dev-config.json
+++ b/config/dev-config.json
@@ -3,10 +3,9 @@
     "chooseLocation": {
       "enabled": false
     },
-    "provider":{
-      "type":"oauth2",
-      "loginUrl":"/bahmni/home",
-      "logoutUrl":"/bahmni/home"
+    "logo": {
+      "src": "https://images.squarespace-cdn.com/content/v1/54358a40e4b0d0810faf80c2/1449227490774-VM0J81B5NXHRUIGXPF5H/Bahmni+logo+black+font.png?format=100w",
+      "alt": "Bahmni Logo"
     }
   },
   "@openmrs/esm-primary-navigation-app": {

--- a/config/dev-config.json
+++ b/config/dev-config.json
@@ -11,6 +11,13 @@
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
       "name": " "
+    },
+    "extensionSlots": {
+      "top-nav-actions-slot": {
+        "remove": [
+          "add-patient-action"
+        ]
+      }
     }
   },
   "@openmrs/esm-patient-search-app": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "homepage": "https://github.com/bahmni/bahmni-lab-frontend#readme",
   "scripts": {
-    "bahmni": "npx openmrs develop --spa-path '/lab' --importmap 'config/dev-importmap.json' --config-url http://localhost:8201/config/config.json --port 8200 --backend 'http://localhost:8080'",
+    "bahmni": "npx openmrs develop --spa-path '/lab' --importmap 'config/dev-importmap.json' --config-url http://localhost:8201/config/dev-config.json --port 8200 --backend 'http://localhost:8080'",
     "omrs:appshell": "npx openmrs build --spa-path /lab --api-url '/openmrs' --config-path 'config/config.json' --target 'omrs-app-shell'",
     "omrs:assemble": "npx openmrs assemble --config 'config/spa-build-config.json' --mode 'config' --target 'omrs-app-shell'",
     "importmap": "node ./tools/updateImportMap.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,20 +5,20 @@ export const patientLabDetailsPath = 'patient/${patientUuid}'
 export const patientLabDetailsRoute = '/patient/:patientUuid'
 export const labOrderUuid = '8189b409-3f10-11e4-adec-0800271c1b75'
 export const defaultPageSize = 5
-
+export const labHomePath = '/lab/home'
+export const bahmniHomePath = '/bahmni/home'
 
 export const headers = [
-    {
-      key: 'date',
-      header: 'Date',
-    },
-    {
-      key: 'testName',
-      header: 'Test',
-    },
-    {
-      key: 'orderedBy',
-      header: 'Ordered By',
-    },
-  ]
-  
+  {
+    key: 'date',
+    header: 'Date',
+  },
+  {
+    key: 'testName',
+    header: 'Test',
+  },
+  {
+    key: 'orderedBy',
+    header: 'Ordered By',
+  },
+]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,8 +5,7 @@ export const patientLabDetailsPath = 'patient/${patientUuid}'
 export const patientLabDetailsRoute = '/patient/:patientUuid'
 export const labOrderUuid = '8189b409-3f10-11e4-adec-0800271c1b75'
 export const defaultPageSize = 5
-export const labHomePath = '/lab/home'
-export const bahmniHomePath = '/bahmni/home'
+export const homePath = '/bahmni/home'
 
 export const headers = [
   {

--- a/src/home-button/home-button.scss
+++ b/src/home-button/home-button.scss
@@ -5,8 +5,3 @@
       color: white;
     }
 }
-
-
-
-
-

--- a/src/home-button/home-button.scss
+++ b/src/home-button/home-button.scss
@@ -1,0 +1,12 @@
+@import "~@openmrs/esm-styleguide/src/vars";
+.headerGlobalBarButton {
+    @include brand-01(background-color);
+    .home {
+      color: white;
+    }
+}
+
+
+
+
+

--- a/src/home-button/home-button.test.tsx
+++ b/src/home-button/home-button.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import HomeButton from './home-button'
+import {bahmniHomePath, labHomePath} from '../constants'
+import userEvent from '@testing-library/user-event'
+
+describe('home button', () => {
+  beforeEach(() => {
+    window = Object.create(window)
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: '',
+      },
+    })
+  })
+
+  it('should show the home button', () => {
+    render(<HomeButton />)
+    expect(
+      screen.getByRole('button', {
+        name: /Home/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('Home')).toBeInTheDocument()
+    // by classname
+    expect(
+      screen.getByLabelText('Home').getElementsByTagName('svg'),
+    ).toBeTruthy()
+  })
+
+  it('should route to home path', () => {
+    process.env.NODE_ENV = 'production'
+
+    render(<HomeButton />)
+
+    userEvent.click(screen.getByLabelText('Home'))
+    expect(window.location.href).toEqual(bahmniHomePath)
+  })
+
+  it('should route to lab home when node environment is update to development', () => {
+    process.env.NODE_ENV = 'development'
+
+    render(<HomeButton />)
+
+    userEvent.click(screen.getByLabelText('Home'))
+    expect(window.location.href).toEqual(labHomePath)
+  })
+})

--- a/src/home-button/home-button.test.tsx
+++ b/src/home-button/home-button.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {render, screen} from '@testing-library/react'
 import HomeButton from './home-button'
-import {bahmniHomePath, labHomePath} from '../constants'
 import userEvent from '@testing-library/user-event'
 
 describe('home button', () => {
@@ -15,35 +14,19 @@ describe('home button', () => {
     })
   })
 
-  it('should show the home button', () => {
+  it('should show the home button on navigation header', () => {
     render(<HomeButton />)
     expect(
       screen.getByRole('button', {
         name: /Home/i,
       }),
     ).toBeInTheDocument()
-    expect(screen.getByLabelText('Home')).toBeInTheDocument()
-    // by classname
-    expect(
-      screen.getByLabelText('Home').getElementsByTagName('svg'),
-    ).toBeTruthy()
   })
 
-  it('should route to home path', () => {
-    process.env.NODE_ENV = 'production'
-
+  it('should route to home path when user clicks on home button', () => {
     render(<HomeButton />)
 
     userEvent.click(screen.getByLabelText('Home'))
-    expect(window.location.href).toEqual(bahmniHomePath)
-  })
-
-  it('should route to lab home when node environment is update to development', () => {
-    process.env.NODE_ENV = 'development'
-
-    render(<HomeButton />)
-
-    userEvent.click(screen.getByLabelText('Home'))
-    expect(window.location.href).toEqual(labHomePath)
+    expect(window.location.href).toEqual('/bahmni/home')
   })
 })

--- a/src/home-button/home-button.tsx
+++ b/src/home-button/home-button.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styles from './home-button.scss'
-import HomeFilled24 from '@carbon/icons-react/lib/Home/24'
+import Home24 from '@carbon/icons-react/lib/home/24'
 import {labHomePath, bahmniHomePath} from '../constants'
 import {HeaderGlobalAction} from 'carbon-components-react'
 
@@ -14,7 +14,7 @@ const HomeButton = () => {
           process.env.NODE_ENV === 'development' ? labHomePath : bahmniHomePath
       }}
     >
-      <HomeFilled24 className={styles.home} />
+      <Home24 className={styles.home} />
     </HeaderGlobalAction>
   )
 }

--- a/src/home-button/home-button.tsx
+++ b/src/home-button/home-button.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styles from './home-button.scss'
 import Home24 from '@carbon/icons-react/lib/home/24'
-import {labHomePath, bahmniHomePath} from '../constants'
+import {homePath} from '../constants'
 import {HeaderGlobalAction} from 'carbon-components-react'
 
 const HomeButton = () => {
@@ -10,8 +10,7 @@ const HomeButton = () => {
       aria-label="Home"
       className={styles.headerGlobalBarButton}
       onClick={() => {
-        window.location.href =
-          process.env.NODE_ENV === 'development' ? labHomePath : bahmniHomePath
+        window.location.href = homePath
       }}
     >
       <Home24 className={styles.home} />

--- a/src/home-button/home-button.tsx
+++ b/src/home-button/home-button.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import styles from './home-button.scss'
+import HomeFilled24 from '@carbon/icons-react/lib/Home/24'
+import {labHomePath, bahmniHomePath} from '../constants'
+import {HeaderGlobalAction} from 'carbon-components-react'
+
+const HomeButton = () => {
+  return (
+    <HeaderGlobalAction
+      aria-label="Home"
+      className={styles.headerGlobalBarButton}
+      onClick={() => {
+        window.location.href =
+          process.env.NODE_ENV === 'development' ? labHomePath : bahmniHomePath
+      }}
+    >
+      <HomeFilled24 className={styles.home} />
+    </HeaderGlobalAction>
+  )
+}
+
+export default HomeButton

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,16 @@ function setupOpenMRS() {
         }),
       },
     ],
+    extensions: [
+      {
+        name: 'home-button',
+        load: getAsyncLifecycle(
+          () => import('./home-button/home-button'),
+          options,
+        ),
+        slot: 'top-nav-info-slot',
+      },
+    ],
   }
 }
 


### PR DESCRIPTION
co-authored by Priyanka Ajmera <pajmera@thoughtworks.com>

## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [ ] I have updated the documentation on [Bahmni Wiki](https://bahmni.atlassian.net/wiki/spaces/BAH/overview) or [README](https://github.com/Bahmni/bahmni-lab-frontend/blob/main/README.md) (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Summary
Right now, the user does not have the option to exit from lab lite and go back to the landing screen (dashboard) of Bahmni. This feature is available in all the other modules.  We want to have a “home” button , on the click of which , the user would be on the landing screen of Bahmni .


## Screenshots
<img width="1792" alt="Screenshot 2022-05-10 at 2 42 36 PM" src="https://user-images.githubusercontent.com/87061265/167600466-859c294d-ac7c-43e1-8cef-9b4f76a6482f.png">


## JIRA tickets
https://bahmni.atlassian.net/jira/software/c/projects/BAH/boards/35?modal=detail&selectedIssue=BAH-1632

