### PR TITLE
BAH-1950 | Bug Fix for removing panel tests from available tests

### DIFF
--- a/src/doctors-list-dropdown/doctor-list-dropdown.tsx
+++ b/src/doctors-list-dropdown/doctor-list-dropdown.tsx
@@ -24,6 +24,7 @@ const DoctorListDropdown = () => {
       }
       setDoctor(requestedBy)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedPendingOrder])
 
   useEffect(() => {

--- a/src/select-test/select-test.tsx
+++ b/src/select-test/select-test.tsx
@@ -90,15 +90,6 @@ const SelectTest = ({isDiscardButtonClicked}) => {
         ) > -1,
     )
     handleMultipleSelect(initialSelectedFromOrdersTable, allTests)
-    if (selectedPendingOrder.length > 0) {
-      const tempSearchResults = allTests.filter(
-        pendingOrderTest =>
-          selectedPendingOrder.findIndex(
-            tempPendingTest =>
-              tempPendingTest?.conceptUuid === pendingOrderTest.uuid,
-          ) === -1,
-      )
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedPendingOrder, labTestResults])
 
@@ -193,7 +184,9 @@ const SelectTest = ({isDiscardButtonClicked}) => {
     selectedTests: Array<LabTest>,
     allTests: Array<LabTest>,
   ) => {
+    let updatedTests: Array<LabTest> = allTests
     selectedTests.forEach(selectedTest => {
+      const remainingTests = filterTests(updatedTests, selectedTest)
       if (!isLabTest(selectedTest)) {
         let listOfSelectedTests = selectedTests
         for (let testInPanel of getTestsInLabOrder(selectedTest)) {
@@ -207,8 +200,11 @@ const SelectTest = ({isDiscardButtonClicked}) => {
           if (isTestInPanel)
             listOfSelectedTests = filterTests(listOfSelectedTests, testInPanel)
         }
-        removeTestsInPanel(selectedTest, allTests)
+        updatedTests = removeTestsInPanel(selectedTest, remainingTests)
+      } else {
+        updatedTests = remainingTests
       }
+      setSearchResults(updatedTests)
       setSelectedTests((prevSelectedTest: Array<LabTest>) => [
         ...prevSelectedTest,
         selectedTest,
@@ -234,6 +230,7 @@ const SelectTest = ({isDiscardButtonClicked}) => {
       }
     }
     setSearchResults(tests)
+    return tests
   }
 
   const handleUnselect = (unselectedTest: LabTest) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [x] I have updated the documentation on [Bahmni Wiki](https://bahmni.atlassian.net/wiki/spaces/BAH/overview) or [README](https://github.com/Bahmni/bahmni-lab-frontend/blob/main/README.md) (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary
When a panel test is selected in "Pending Lab Orders" and upload report button is clicked then the tests which are present in panel is not moving out from Available Tests Section. Also, duplicate Tests/Panels displayed under selected tests section
are removed. 

## Screenshots
<img width="1780" alt="image" src="https://user-images.githubusercontent.com/91885483/179945927-7d3d950c-8395-41a0-b67c-e546b59a9ba9.png">


## JIRA tickets
https://bahmni.atlassian.net/jira/software/c/projects/BAH/boards/35?modal=detail&selectedIssue=BAH-2027
https://bahmni.atlassian.net/jira/software/c/projects/BAH/boards/35?modal=detail&selectedIssue=BAH-1950

