### PR TITLE
BAH-2015 | Closing of open orders

### DIFF
--- a/src/__mocks__/pendingLabOrders.mock.ts
+++ b/src/__mocks__/pendingLabOrders.mock.ts
@@ -1,3 +1,4 @@
+import {orderStatusCompleted} from '../constants'
 import {LabOrdersFetchResponse} from '../types'
 
 export const mockPendingLabOrdersResponse: LabOrdersFetchResponse = {
@@ -10,7 +11,8 @@ export const mockPendingLabOrdersResponse: LabOrdersFetchResponse = {
       orderDate: 1657188240000,
       orderUuid: 'abc-123',
       provider: 'Super Man',
-      providerUuid:'1'
+      providerUuid: '1',
+      fulfillerStatus: null,
     },
     {
       concept: {
@@ -20,7 +22,8 @@ export const mockPendingLabOrdersResponse: LabOrdersFetchResponse = {
       orderDate: 1657187934000,
       orderUuid: 'abd-123',
       provider: 'Super Man',
-      providerUuid:'2'
+      providerUuid: '2',
+      fulfillerStatus: null,
     },
   ],
 }

--- a/src/__mocks__/selectTests.mock.ts
+++ b/src/__mocks__/selectTests.mock.ts
@@ -303,7 +303,7 @@ export const uploadFileRequestBody =
   '{"content":",Y29udGVudA==","encounterTypeName":"Patient Document","fileType":"application","format":"pdf","patientUuid":"123"}'
 
 export const diagnosticReportRequestBody = reportDate =>
-  `{"resourceType":"DiagnosticReport","status":"final","code":{"coding":[{"code":"07a128f7-f596-45d5-a2a9-c447bc9e5112","display":"Absolute Eosinphil Count"}]},"subject":{"reference":"Patient/123"},"issued":"${reportDate}","conclusion":"Normal Report","presentedForm":[{"url":"100/76-Patient Document-7baff463-fdaa-43d0-a402-aa948c296958.pdf","title":"test.pdf"}],"performer":{"reference":"Practitioner/1"}}`
+  `{"resourceType":"DiagnosticReport","status":"final","code":{"coding":[{"code":"07a128f7-f596-45d5-a2a9-c447bc9e5112","display":"Absolute Eosinphil Count"}]},"subject":{"reference":"Patient/123"},"issued":"${reportDate}","presentedForm":[{"url":"100/76-Patient Document-7baff463-fdaa-43d0-a402-aa948c296958.pdf","title":"test.pdf"}],"conclusion":"Normal Report","performer":[{"reference":"Practitioner/1"}]}`
 
 export const selfDiagnosticRequestBody = reportDate =>
-  `{"resourceType":"DiagnosticReport","status":"final","code":{"coding":[{"code":"07a128f7-f596-45d5-a2a9-c447bc9e5112","display":"Absolute Eosinphil Count"}]},"subject":{"reference":"Patient/123"},"issued":"${reportDate}","conclusion":"","presentedForm":[{"url":"100/76-Patient Document-7baff463-fdaa-43d0-a402-aa948c296958.pdf","title":"test.pdf"}]}`
+  `{"resourceType":"DiagnosticReport","status":"final","code":{"coding":[{"code":"07a128f7-f596-45d5-a2a9-c447bc9e5112","display":"Absolute Eosinphil Count"}]},"subject":{"reference":"Patient/123"},"issued":"${reportDate}","presentedForm":[{"url":"100/76-Patient Document-7baff463-fdaa-43d0-a402-aa948c296958.pdf","title":"test.pdf"}]}`

--- a/src/__mocks__/selectTests.mock.ts
+++ b/src/__mocks__/selectTests.mock.ts
@@ -303,7 +303,7 @@ export const uploadFileRequestBody =
   '{"content":",Y29udGVudA==","encounterTypeName":"Patient Document","fileType":"application","format":"pdf","patientUuid":"123"}'
 
 export const diagnosticReportRequestBody = reportDate =>
-  `{"resourceType":"DiagnosticReport","status":"final","code":{"coding":[{"code":"07a128f7-f596-45d5-a2a9-c447bc9e5112","display":"Absolute Eosinphil Count"}]},"subject":{"reference":"Patient/123"},"issued":"${reportDate}","conclusion":"Normal Report","presentedForm":{"url":"100/76-Patient Document-7baff463-fdaa-43d0-a402-aa948c296958.pdf","title":"test.pdf"},"basedOn":null,"performer":{"reference":"Practitioner/1"}}`
+  `{"resourceType":"DiagnosticReport","status":"final","code":{"coding":[{"code":"07a128f7-f596-45d5-a2a9-c447bc9e5112","display":"Absolute Eosinphil Count"}]},"subject":{"reference":"Patient/123"},"issued":"${reportDate}","conclusion":"Normal Report","presentedForm":[{"url":"100/76-Patient Document-7baff463-fdaa-43d0-a402-aa948c296958.pdf","title":"test.pdf"}],"performer":{"reference":"Practitioner/1"}}`
 
 export const selfDiagnosticRequestBody = reportDate =>
-  `{"resourceType":"DiagnosticReport","status":"final","code":{"coding":[{"code":"07a128f7-f596-45d5-a2a9-c447bc9e5112","display":"Absolute Eosinphil Count"}]},"subject":{"reference":"Patient/123"},"issued":"${reportDate}","conclusion":"","presentedForm":{"url":"100/76-Patient Document-7baff463-fdaa-43d0-a402-aa948c296958.pdf","title":"test.pdf"},"basedOn":null}`
+  `{"resourceType":"DiagnosticReport","status":"final","code":{"coding":[{"code":"07a128f7-f596-45d5-a2a9-c447bc9e5112","display":"Absolute Eosinphil Count"}]},"subject":{"reference":"Patient/123"},"issued":"${reportDate}","conclusion":"","presentedForm":[{"url":"100/76-Patient Document-7baff463-fdaa-43d0-a402-aa948c296958.pdf","title":"test.pdf"}]}`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const selfPatient = 'self (patient)'
 export const orderTypeUuidKey = 'orderTypeUuid'
 export const labOrderType = 'Lab Order'
 export const practitionerRoleDoctor = 'practioner_role: Doctor'
+export const orderStatusCompleted = 'COMPLETED'
 
 export const headers = [
   {

--- a/src/patient-lab-details/patient-lab-details.test.tsx
+++ b/src/patient-lab-details/patient-lab-details.test.tsx
@@ -477,7 +477,7 @@ describe('Patient lab details', () => {
     expect(mockedOpenmrsFetch).toBeCalledTimes(7)
     expect(mockedOpenmrsFetch.mock.calls[5][1].method).toBe('POST')
     expect(mockedOpenmrsFetch.mock.calls[6][1].method).toBe('POST')
-    expect(mutateMock).toHaveBeenCalledTimes(1)
+    expect(mutateMock).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/patient-lab-details/patient-lab-details.test.tsx
+++ b/src/patient-lab-details/patient-lab-details.test.tsx
@@ -401,7 +401,7 @@ describe('Patient lab details', () => {
 
     expect(
       JSON.parse(mockedOpenmrsFetch.mock.calls[5][1].body).performer,
-    ).toStrictEqual({reference: 'Practitioner/1'})
+    ).toStrictEqual([{reference: 'Practitioner/1'}])
   })
 
   it('should make multiple POST calls when multiple tests are selected', async () => {

--- a/src/patient-lab-details/patient-lab-details.tsx
+++ b/src/patient-lab-details/patient-lab-details.tsx
@@ -95,6 +95,7 @@ const PatientLabDetails: React.FC<RouteComponentProps<PatientParamsType>> = ({
             <PaginatedTable
               patientUuid={patientUuid}
               onButtonClick={onButtonClick}
+              reloadTableData={reloadReportTable}
             />
             <br></br>
             <br></br>

--- a/src/table/paginated-table.test.tsx
+++ b/src/table/paginated-table.test.tsx
@@ -58,6 +58,7 @@ describe('Paginated Table', () => {
         <BrowserRouter>
           <PendingLabOrdersProvider>
             <PaginatedTable
+              reloadTableData={false}
               patientUuid={mockPatientUuid}
               onButtonClick={false}
             />
@@ -126,6 +127,7 @@ describe('Paginated Table', () => {
         <BrowserRouter>
           <PendingLabOrdersProvider>
             <PaginatedTable
+              reloadTableData={false}
               patientUuid={mockPatientUuid}
               onButtonClick={false}
             />
@@ -154,6 +156,7 @@ describe('Paginated Table', () => {
         <BrowserRouter>
           <PendingLabOrdersProvider>
             <PaginatedTable
+              reloadTableData={false}
               patientUuid={mockPatientUuid}
               onButtonClick={false}
             />
@@ -183,6 +186,7 @@ describe('Paginated Table', () => {
         <SWRConfig value={{provider: () => new Map()}}>
           <BrowserRouter>
             <PaginatedTable
+              reloadTableData={false}
               patientUuid={mockPatientUuid}
               onButtonClick={false}
             />

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -4,6 +4,7 @@ export interface LabOrders {
   orderUuid: string
   provider: string
   providerUuid: string
+  fulfillerStatus: string
 }
 
 interface Concept {
@@ -94,17 +95,17 @@ export interface PendingLabOrders {
 }
 
 export interface Attribute {
-      display: string,
-      uuid: string,
-      attributeType: {
-          uuid: string,
-          display: string,
-          retired: undefined | boolean
-          links: Array<Links>
-        },
-      value: boolean,
-      voided: boolean,
-      links: Array<Links>
+  display: string
+  uuid: string
+  attributeType: {
+    uuid: string
+    display: string
+    retired: undefined | boolean
+    links: Array<Links>
+  }
+  value: boolean
+  voided: boolean
+  links: Array<Links>
 }
 export interface ReportTableRow {
   id: string

--- a/src/upload-report/upload-report.resources.tsx
+++ b/src/upload-report/upload-report.resources.tsx
@@ -44,13 +44,13 @@ interface DiagnosticReportRequestType {
   }
   subject: ReferenceRequestType
   issued: Date
-  conclusion: string
+  conclusion?: string
   presentedForm: Array<{
     url: string
     title: string
   }>
   basedOn?: Array<BasedOnType>
-  performer?: ReferenceRequestType
+  performer?: Array<ReferenceRequestType>
 }
 
 export function uploadFile(
@@ -112,16 +112,20 @@ export function saveDiagnosticReport(
       reference: 'Patient/' + patientUuid,
     },
     issued: reportDate,
-    conclusion: reportConclusion,
     presentedForm: [{url: uploadFileUrl, title: uploadedFileName}],
+  }
+  if (reportConclusion) {
+    requestBody.conclusion = reportConclusion
   }
   if (pendingOrderInPayload.length == 1) {
     requestBody.basedOn = basedOn
   }
   if (performerUuid) {
-    requestBody.performer = {
-      reference: 'Practitioner/' + performerUuid,
-    }
+    requestBody.performer = [
+      {
+        reference: 'Practitioner/' + performerUuid,
+      },
+    ]
   }
 
   return postApiCall(saveDiagnosticReportURL, requestBody, ac)

--- a/src/upload-report/upload-report.test.tsx
+++ b/src/upload-report/upload-report.test.tsx
@@ -77,7 +77,7 @@ describe('Upload Report', () => {
       new Date(currentDay).toLocaleDateString('en', {
         year: 'numeric',
         month: '2-digit',
-        day: 'numeric',
+        day: '2-digit',
       }),
     )
     await waitFor(() =>
@@ -473,7 +473,7 @@ describe('Upload Report', () => {
       expect(saveButton).not.toBeDisabled()
     })
   })
-  
+
   it('should disable save and upload button after first click', async () => {
     const file = new File(['content'], 'test.pdf', {type: 'application/pdf'})
     localStorage.setItem('i18nextLng', 'en')

--- a/src/upload-report/upload-report.tsx
+++ b/src/upload-report/upload-report.tsx
@@ -44,7 +44,10 @@ const UploadReport: React.FC<UploadReportProps> = ({
   const {selectedTests, setSelectedTests} = useSelectedTests()
   const maxCount: number = 500
   const {selectedFile, setSelectedFile} = useSelectedFile()
-  const {selectedPendingOrder} = usePendingLabOrderContext()
+  const {
+    selectedPendingOrder,
+    setSelectedPendingOrder,
+  } = usePendingLabOrderContext()
   const [showReportConclusionLabel, setShowReportConclusionLabel] = useState<
     boolean
   >(true)
@@ -145,8 +148,12 @@ const UploadReport: React.FC<UploadReportProps> = ({
         allSuccess = false
       }
     }
-
-    allSuccess ? close(true) : setIsSaveButtonClicked(false)
+    if (allSuccess) {
+      close(true)
+      setSelectedPendingOrder([])
+    } else {
+      setIsSaveButtonClicked(false)
+    }
   }
 
   return (

--- a/src/utils/lab-orders.ts
+++ b/src/utils/lab-orders.ts
@@ -1,9 +1,6 @@
 import {openmrsFetch} from '@openmrs/esm-framework'
 import {maxPageSizeForDiagnosticReport} from '../constants'
 
-export const getPendingLabOrdersURL = patientUuid =>
-  `/ws/rest/v1/order?patient=${patientUuid}&orderType=Lab Order&v=default`
-
 export const fetcher = url =>
   openmrsFetch(url, {
     method: 'GET',


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [x] I have updated the documentation on [Bahmni Wiki](https://bahmni.atlassian.net/wiki/spaces/BAH/overview) or [README](https://github.com/Bahmni/bahmni-lab-frontend/blob/main/README.md) (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary
The pending lab orders table currently displays all orders. We would want the table to display only the active/pending lab orders. To do this, we would need to ensure that when the user uploads a report against the open orders, that order is marked as closed and removed from the table.

## Screenshots
<img width="1784" alt="image" src="https://user-images.githubusercontent.com/91885483/180939905-ec853c30-3f30-4e28-bc1b-951c49e0b91c.png">

<img width="1783" alt="image" src="https://user-images.githubusercontent.com/91885483/180940070-b53b97eb-7b12-47f8-b404-8da9a09008d5.png">


## JIRA tickets
https://bahmni.atlassian.net/jira/software/c/projects/BAH/boards/35?modal=detail&selectedIssue=BAH-2015

## Other
<!-- Anything not covered above -->
