### PR TITLE
 BAH-4222|Fix i18n namespace to load translations correctly

### DIFF
--- a/src/common/loader/loader.component.tsx
+++ b/src/common/loader/loader.component.tsx
@@ -4,7 +4,7 @@ import {InlineLoading} from 'carbon-components-react'
 import {useTranslation} from 'react-i18next'
 
 const Loader: React.FC = () => {
-  const {t} = useTranslation()
+  const {t} = useTranslation('@bahmni/lab-app')
   return (
     <InlineLoading
       className={styles.loading}

--- a/src/home/home.tsx
+++ b/src/home/home.tsx
@@ -26,13 +26,14 @@ import {
   loggedInUserKey,
   userLocationKey,
   activePatientHeaders,
+  labAppNamespace,
 } from '../utils/constants'
 import classes from './home.scss'
 interface AuditLogResponse {
   data: boolean
 }
 const Home = () => {
-  const {t} = useTranslation('@bahmni/lab-app')
+  const {t} = useTranslation(labAppNamespace)
   const [loggedInUser, setLoggedInUser] = useState<LoggedInUser | null>(null)
 
   let {data: auditLogEnabledResponse, error: auditLogResponseError} = useSWR<
@@ -131,9 +132,11 @@ const Home = () => {
       <div className={classes.image}>
         <img src={BahmniLogo} alt="Bahmni Logo" />
       </div>
-      <h1 className={classes.welcomeText}>WELCOME TO LAB ENTRY</h1>
+      <h1 className={classes.welcomeText}>
+        {t('welcome', 'WELCOME TO LAB ENTRY')}
+      </h1>
       <span className={classes.helpText}>
-        Please click on the search icon above to get started
+        {t('helpText', 'Please click on the search icon above to get started')}
       </span>
       {renderPatientTable()}
     </div>

--- a/src/home/home.tsx
+++ b/src/home/home.tsx
@@ -32,7 +32,7 @@ interface AuditLogResponse {
   data: boolean
 }
 const Home = () => {
-  const {t} = useTranslation()
+  const {t} = useTranslation('@bahmni/lab-app')
   const [loggedInUser, setLoggedInUser] = useState<LoggedInUser | null>(null)
 
   let {data: auditLogEnabledResponse, error: auditLogResponseError} = useSWR<

--- a/src/patient-lab-dashboard/patient-lab-root.test.tsx
+++ b/src/patient-lab-dashboard/patient-lab-root.test.tsx
@@ -1,8 +1,8 @@
-import { openmrsFetch } from '@openmrs/esm-framework'
-import { render, screen, waitFor } from '@testing-library/react'
+import {openmrsFetch} from '@openmrs/esm-framework'
+import {render, screen, waitFor} from '@testing-library/react'
 import React from 'react'
-import { of } from 'rxjs'
-import { mockUnauthorizedUser, mockUser } from '../__mocks__/mockUser'
+import {of} from 'rxjs'
+import {mockUnauthorizedUser, mockUser} from '../__mocks__/mockUser'
 import Root from './patient-lab-root.component'
 
 const mockUserObservable = of(mockUser)
@@ -34,11 +34,16 @@ jest.mock('react-router-dom', () => {
   }
 })
 
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string) => defaultValue || key,
+  }),
+}))
+
 describe('Root', () => {
   it('should render home when user hits home url', async () => {
     let mockedOpenmrsFetch = openmrsFetch as jest.Mock
-    mockedOpenmrsFetch
-      .mockReturnValueOnce({data: true})
+    mockedOpenmrsFetch.mockReturnValueOnce({data: true})
     window.history.pushState({}, 'Lab Entry', '/lab/home')
     render(<Root />)
     await waitFor(() =>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,7 @@
 export const spaRoot = window['getOpenmrsSpaBase']()
 export const labliteModuleName = '@bahmni/lab-lite-app'
 export const searchModuleName = '@openmrs/esm-patient-search-app'
+export const labAppNamespace = '@bahmni/lab-app'
 export const patientLabDetailsPath = 'patient/${patientUuid}'
 export const patientLabDetailsRoute = '/patient/:patientUuid'
 export const labOrderUuid = '8189b409-3f10-11e4-adec-0800271c1b75'

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,5 +1,7 @@
 {
   "title": "Lab Entry App",
+  "welcome": "Welcome To Lab Entry",
+  "helpText": "Please Click On The Search Icon Above To Get Started",
   "activePatientList": "Active Patient List",
   "patientId": "Patient Id",
   "patientName": "Patient Name",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1,5 +1,7 @@
 {
   "title": "Application d'Entrée de Laboratoire",
+  "welcome": "Bienvenue à l'entrée du laboratoire",
+  "helpText": "Veuillez Cliquer Sur L'icône De Recherche Ci-dessus Pour Commencer",
   "activePatientList": "Liste des Patients Actifs",
   "patientId": "ID Patient",
   "patientName": "Nom du Patient",


### PR DESCRIPTION
Problem: i18 translations not loading properly
Root Cause:The OpenMRS app shell registers module translations under the                                                                                                     
  importmap key as the i18n namespace. This module is registered
  as `@bahmni/lab-app` in importmap.json.                                                                                                                             
   
  `useTranslation()` was called without a namespace, defaulting to                                                                                                    
  the `translation` namespace instead of `@bahmni/lab-app` — causing                                                                                                
  i18next to never find the translation keys and always fall back to                                                                                                  
  English values.    
solution:  Pass the correct namespace to `useTranslation()`:                                                                                                                 
      Before -const {t} = useTranslation()

       After  -const {t} = useTranslation('@bahmni/lab-app')                                                                                                                                                  