### PR TITLE
BAH-4708: Fix critical security vulnerabilities on bahmni-lab docker image

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine3.18
+FROM nginx:stable-alpine3.23
 
 RUN apk add --update openssl && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
**JIRA**: BAH-4708

### What Changed
- `package/docker/Dockerfile`: bump base image from `nginx:alpine3.18` to `nginx:stable-alpine3.23`.

### Why
Alpine 3.18 reached end-of-life on 2025-05-09 and no longer receives CVE patches, which is the source of the 3 CRITICAL vulnerabilities Trivy reports against `bahmni/bahmni-lab`. Pinning to `nginx:stable-alpine3.23` (current supported nginx stable on Alpine 3.23) clears them without changing the image surface.

### How Tested
- [x] Pulled `nginx:stable-alpine3.23` — multi-arch (amd64 + arm64) confirmed.
- [x] Smoke-built the base + `apk add openssl` + cert generation + nginx layout steps on the new base — passes.
- [x] Trivy scan: old base 3 CRITICAL / 17 HIGH → new base 0 CRITICAL / 0 HIGH.
- [ ] CI build of the full image with `dist/` artifacts (will run on PR).

### Acceptance Criteria Met
- [x] 3 CRITICAL vulnerabilities on `bahmni/bahmni-lab` eliminated.
- [x] No regression to the Dockerfile build flow.